### PR TITLE
fix for numbers that couldn't be used

### DIFF
--- a/src/PseudoCrypt/PseudoCrypt.php
+++ b/src/PseudoCrypt/PseudoCrypt.php
@@ -32,7 +32,7 @@ class PseudoCrypt {
  
     public static function base62($int) {
         $key = "";
-        while(bccomp($int-1, 0) > 0) {
+        while(bccomp($int, 0) > 0) {
             $mod = bcmod($int, 62);
             $key .= chr(self::$chars62[$mod]);
             $int = bcdiv($int, 62);


### PR DESCRIPTION
Basically reverting connyay's change.
He probably based his change on Omar's comment on February 13th, 2013, in the original page (http://web.archive.org/web/20130727034425/http://blog.kevburnsjr.com/php-unique-hash).
I couldn't reproduce Omar's error that based the modification.
The current code fails for some integers, at least with the parameters we are using.